### PR TITLE
Make the library available by Windows Runtime Apps.

### DIFF
--- a/src/ImsGlobal.Caliper/ImsGlobal.Caliper.csproj
+++ b/src/ImsGlobal.Caliper/ImsGlobal.Caliper.csproj
@@ -9,6 +9,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ImsGlobal.Caliper</RootNamespace>
     <AssemblyName>ImsGlobal.Caliper</AssemblyName>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -33,27 +35,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NodaTime">
-      <HintPath>..\..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
-    </Reference>
-    <Reference Include="NodaTime.Serialization.JsonNet">
-      <HintPath>..\..\packages\NodaTime.Serialization.JsonNet.1.3.1\lib\net35-Client\NodaTime.Serialization.JsonNet.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NodaTime.1.3.1\lib\portable-net4+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1+XamariniOS1\NodaTime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <Reference Include="NodaTime.Serialization.JsonNet, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NodaTime.Serialization.JsonNet.1.3.1\lib\portable-net4+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\NodaTime.Serialization.JsonNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Entities\Agent\Agent.cs" />
@@ -154,7 +146,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/ImsGlobal.Caliper/Protocol/CaliperClient.cs
+++ b/src/ImsGlobal.Caliper/Protocol/CaliperClient.cs
@@ -55,7 +55,7 @@ namespace ImsGlobal.Caliper.Protocol {
 
 				} catch( HttpRequestException ex ) {
 					var msg = String.Format( "Failed to send data: {0}", ex.Message );
-					Trace.WriteLine( msg );
+					Debug.WriteLine( msg );
 					return false;
 				}
 			}

--- a/src/ImsGlobal.Caliper/packages.config
+++ b/src/ImsGlobal.Caliper/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="NodaTime" version="1.3.1" targetFramework="net45" />
-  <package id="NodaTime.Serialization.JsonNet" version="1.3.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable-net45+win+wpa81" />
+  <package id="NodaTime" version="1.3.1" targetFramework="portable-net45+win+wpa81" />
+  <package id="NodaTime.Serialization.JsonNet" version="1.3.1" targetFramework="portable-net45+win+wpa81" />
 </packages>


### PR DESCRIPTION
This library would be more useful if it supported Windows Runtime environment -- Windows Store 8.0/8.1, Windows Phone 8.1, and Universal Windows Platform -- as well as .NET Framework 4.5.
NOTE: Don't forget to modify the "requirement" section in README after merge.